### PR TITLE
JDK-8274347: Do not use switch expressions inline with method call parameters

### DIFF
--- a/jasm-composition-jvm/src/main/java/me/darknet/assembler/compile/visitor/BlwRootVisitor.java
+++ b/jasm-composition-jvm/src/main/java/me/darknet/assembler/compile/visitor/BlwRootVisitor.java
@@ -1,5 +1,6 @@
 package me.darknet.assembler.compile.visitor;
 
+import dev.xdark.blw.annotation.AnnotationBuilder;
 import dev.xdark.blw.classfile.AccessFlag;
 import dev.xdark.blw.type.InstanceType;
 import dev.xdark.blw.type.MethodType;
@@ -21,7 +22,7 @@ public record BlwRootVisitor(BlwReplaceClassBuilder builder, JvmCompilerOptions 
 
         InstanceType type = builder.type;
 
-        return new BlwAnnotationVisitor(switch (path.length) {
+        AnnotationBuilder.Nested<?> nested = switch (path.length) {
             case 2 -> builder.visibleRuntimeAnnotation(type, index);
             case 5 -> {
                 String member = path[3];
@@ -33,7 +34,8 @@ public record BlwRootVisitor(BlwReplaceClassBuilder builder, JvmCompilerOptions 
                 };
             }
             default -> throw new IllegalStateException("Unexpected value: " + path.length);
-        });
+        };
+        return new BlwAnnotationVisitor(nested);
     }
 
     @Override

--- a/jasm-composition-jvm/src/main/java/me/darknet/assembler/printer/MemberPrinter.java
+++ b/jasm-composition-jvm/src/main/java/me/darknet/assembler/printer/MemberPrinter.java
@@ -36,15 +36,17 @@ public record MemberPrinter(
 
     public PrintContext<?> printDeclaration(PrintContext<?> ctx) {
         if (accessible != null) {
-            return ctx.begin().element(switch (type) {
+            String elementName = switch (type) {
                 case CLASS -> ".class";
                 case FIELD -> ".field";
                 case METHOD -> ".method";
-            }).print(BlwModifiers.modifiers(accessible.accessFlags(), switch (type) {
+            };
+            int modifierType = switch (type) {
                 case CLASS -> BlwModifiers.CLASS;
                 case FIELD -> BlwModifiers.FIELD;
                 case METHOD -> BlwModifiers.METHOD;
-            }));
+            };
+            return ctx.begin().element(elementName).print(BlwModifiers.modifiers(accessible.accessFlags(), modifierType));
         }
         return ctx;
     }


### PR DESCRIPTION
See: https://bugs.openjdk.org/browse/JDK-8274347